### PR TITLE
Minor changes and GetHistogram skips all invalid volumes

### DIFF
--- a/OutputProcessing/GetHistogram.cpp
+++ b/OutputProcessing/GetHistogram.cpp
@@ -35,7 +35,6 @@ along with utr.  If not, see <http://www.gnu.org/licenses/>.
 using std::cout;
 using std::cerr;
 using std::endl;
-using std::min;
 using std::string;
 using std::stringstream;
 using std::vector;
@@ -58,7 +57,7 @@ static struct argp_option options[] = {
 	{ "binning", 'b', "BINNING", 0, "Size of bins in the histogram in keV (default: 1 keV)" },
 	{ "maxenergy", 'e', "EMAX", 0, "Maximum energy displayed in histogram in MeV (rounded up to match BINNING) (default: 10 MeV)" },
 	{ "showbin", 'B', "BIN", 0, "Number of energy bin whose value should be displayed, -1 to disable (default: -1)" },
-	{ "maxid", 'n', "MAXID", 0, "Highest detection volume ID (default: 12). 'getHistogram' expects to only encounter detectors labeled with integer numbers from 0 to MAXID." },
+	{ "maxid", 'n', "MAXID", 0, "Highest detection volume ID (default: 12). 'getHistogram' only processes energy depositions in detectors with integer volume ID numbers from 0 to MAXID." },
 	{ "multiplicity", 'm', "MULTIPLICITY", 0, "Particle multiplicity, sum energy depositions for each detector among MULTIPLICITY events (default: 1)" },
 	{ "addback", 'a', 0, 0, "Add back energy depositions that occurred in a single event to the detector first listed in the event (usually this is the first one hit) (default: Off)" },
 	{ "silent", 's', 0, 0, "Silent mode (does not silence -B option) (default: Off" },
@@ -78,7 +77,7 @@ struct arguments {
 	double binning=1./1000.;
 	double eMax=10.;
 	int binToPrint=-1;
-	unsigned int nhistograms=12;
+	unsigned int nhistograms=12 + 1; // Default value for MAXID of 12 and +1 (histograms 0 to 12)
 	unsigned int multiplicity=1;
 	bool addback=false;
 	bool verbose=true;
@@ -99,7 +98,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 		case 'b': arguments->binning = atof(arg)/1000.; break;
 		case 'e': arguments->eMax = atof(arg); break;
 		case 'B': arguments->binToPrint = atoi(arg); break;
-		case 'n': arguments->nhistograms = (unsigned int) atoi(arg)+1; break;
+		case 'n': arguments->nhistograms = (unsigned int) atoi(arg) + 1; break; // = MAXID + 1 (histograms 0 to MAXID)
 		case 'm': arguments->multiplicity = (unsigned int) atoi(arg); break;
 		case 'a': arguments->addback = true; break;
 		case 's': arguments->verbose = false; break;
@@ -233,18 +232,31 @@ int main(int argc, char* argv[]){
 	}
 
 	unsigned int addback_counter = 0;
+	unsigned int warningCounter = 0;
 	
 	// (Pre)Process first event manually (so it is considered the last event)
 	fileChain.GetEntry(0);
+	long entry = 1;
+	while ((unsigned int) Volume >= arguments.nhistograms && entry < fileChain.GetEntries()) { // Make sure that always a valid volume is given as the last volume
+		if (warningCounter < 10) {
+			cout << "Warning: Entry with volume = " << (unsigned int) Volume << " > MAXID = " << arguments.nhistograms - 1  << " encountered. Skipping this entry." << endl;
+			warningCounter++;
+			if (warningCounter == 10) {
+				cout << "Warning: No more warnings of this type will be displayed!" << endl;
+			}
+		}
+		fileChain.GetEntry(entry);
+		entry++;
+	}
 	lastEvent=Event;
-	lastVolume=min(arguments.nhistograms-1, (unsigned int) Volume); // The min() ensures that a valid volume is given as the last volume
+	lastVolume=(unsigned int) Volume;
 	EdepBuffer[lastVolume] = Edep;
 
 	//Process next events in loops
-	for(long i = 1; i < fileChain.GetEntries(); ++i) {
+	while(entry < fileChain.GetEntries()) {
 		// Get the entry, this sets the values for the Edep, Volume and Event variables
-		fileChain.GetEntry(i);
-		if((unsigned int) Volume < arguments.nhistograms){
+		fileChain.GetEntry(entry);
+		if((unsigned int) Volume < arguments.nhistograms){ // nhistograms=MAXID+1 so must always be greater than Volume to consider that Volume
 			// If addback is disabled or the event number has changed:
 			if (!arguments.addback || lastEvent != Event) {
 				// First process the *last* event still in the buffer:
@@ -264,9 +276,14 @@ int main(int argc, char* argv[]){
 			}
 			// Add Edep value to buffer (necessary for addback and multiplicity), note that the *last* Volume can now already be *this* event's volume
 			EdepBuffer[lastVolume] += Edep;
-		} else if (arguments.verbose){
+		} else if (arguments.verbose && warningCounter < 10){
 			cout << "Warning: Entry with volume = " << (unsigned int) Volume << " > MAXID = " << arguments.nhistograms - 1  << " encountered. Skipping this entry." << endl;
+			warningCounter++;
+			if (warningCounter == 10) {
+				cout << "Warning: No more warnings of this type will be displayed!" << endl;
+			}
 		}
+		++entry;
 	}
 
 	// (Post)Process last event manually 

--- a/OutputProcessing/GetHistogram.cpp
+++ b/OutputProcessing/GetHistogram.cpp
@@ -57,7 +57,7 @@ static struct argp_option options[] = {
 	{ "binning", 'b', "BINNING", 0, "Size of bins in the histogram in keV (default: 1 keV)" },
 	{ "maxenergy", 'e', "EMAX", 0, "Maximum energy displayed in histogram in MeV (rounded up to match BINNING) (default: 10 MeV)" },
 	{ "showbin", 'B', "BIN", 0, "Number of energy bin whose value should be displayed, -1 to disable (default: -1)" },
-	{ "maxid", 'n', "MAXID", 0, "Highest detection volume ID (default: 12). 'getHistogram' only processes energy depositions in detectors with integer volume ID numbers from 0 to MAXID." },
+	{ "maxid", 'n', "MAXID", 0, "Highest detection volume ID (default: 12). 'getHistogram' only processes energy depositions in detectors with integer volume ID numbers from 0 to MAXID (MAXID is included)." },
 	{ "multiplicity", 'm', "MULTIPLICITY", 0, "Particle multiplicity, sum energy depositions for each detector among MULTIPLICITY events (default: 1)" },
 	{ "addback", 'a', 0, 0, "Add back energy depositions that occurred in a single event to the detector first listed in the event (usually this is the first one hit) (default: Off)" },
 	{ "silent", 's', 0, 0, "Silent mode (does not silence -B option) (default: Off" },
@@ -234,7 +234,14 @@ int main(int argc, char* argv[]){
 	unsigned int addback_counter = 0;
 	unsigned int warningCounter = 0;
 	
-	// (Pre)Process first event manually (so it is considered the last event)
+	// The addback-option compares the event number of the last energy deposition to the present event number.
+	// If the present event number is different from the last one, the energy deposition buffer is filled into
+	// the histogram, set to zero, and then the present energy deposition is added to the buffer.
+	// This procedure requires that the 'last event' has been defined, therefore getHistogram
+	// preprocesses the first event manually.
+	//
+	// A valid last event has a valid detector ID. The following while loop reads entries until it finds a
+	// valid last event.
 	fileChain.GetEntry(0);
 	long entry = 1;
 	while ((unsigned int) Volume >= arguments.nhistograms && entry < fileChain.GetEntries()) { // Make sure that always a valid volume is given as the last volume

--- a/OutputProcessing/utrwrapper.py
+++ b/OutputProcessing/utrwrapper.py
@@ -53,6 +53,9 @@ listing all available options with their effect and default values
 #                                     # to utr's code directory and using all
 #                                     # other supplied paths relative to it
 #                                     # (Default: True)
+#ensureTerminalMultiplexer=False      # Whether to warn and abort if """+ programName +""" 
+#                                     # is not run inside a tmux or GNU Screen 
+#                                     # session (Default: False)
 #cmakeArgs=--debug-output             # Pure string of additional arguments to
 #                                     # cmake on utr, see also [utrBuildOptions]
 #                                     # section (Default: None)
@@ -91,6 +94,7 @@ listing all available options with their effect and default values
 #USE_TARGETS=ON                       # Example
 #GENERATOR_ANGCORR=OFF                # Example
 #GENERATOR_ANGDIST=ON                 # Example
+#ZERODEGREE_OFFSET=30                 # Example
 
 #[getHistogramArgs]                   # Optional section with additional longform
 #                                     # options (--LONGOPTION=VALUE) to getHistogram
@@ -143,6 +147,10 @@ config.optionxform=lambda option: option # Keep keys' case as is, overwrites the
 config.read_string("".join(cfgParts))
 if not config.has_section("generalConfig") :
     exit("ERROR: Extended macro file is missing required section '[generalConfig]' in its configuration header")
+
+# If required by config, script will abort if not run in a TMUX or Screen session
+if config["generalConfig"].getboolean("ensureTerminalMultiplexer", False) and 'TMUX' not in os.environ and 'STY' not in os.environ :
+    exit("ERROR: " + os.path.basename(sys.argv[0]) + " is not run within a tmux or screen session as required by the configuration header! Aborting...")
 
 # Get all options from the configuration
 logging=config["generalConfig"].getboolean("logging", True)

--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,7 @@ Executing
 
 ```bash
 $ ./OutputProcessing/getHistogram --help
-Usage: getHistogram [OPTION...] 
+Usage: getHistogram [OPTION...]
 Create histograms of energy depositions in detectors from a list of events
 stored among multiple ROOT files
 
@@ -1039,7 +1039,7 @@ stored among multiple ROOT files
                              displayed, -1 to disable (default: -1)
   -d, --inputdir=INPUTDIR    Directory to search for input files matching the
                              patterns (default: current working directory '.' )
-                            
+
   -e, --maxenergy=EMAX       Maximum energy displayed in histogram in MeV
                              (rounded up to match BINNING) (default: 10 MeV)
   -m, --multiplicity=MULTIPLICITY
@@ -1047,8 +1047,9 @@ stored among multiple ROOT files
                              each detector among MULTIPLICITY events (default:
                              1)
   -n, --maxid=MAXID          Highest detection volume ID (default: 12).
-                             'getHistogram' expects to only encounter detectors
-                             labeled with integer numbers from 0 to MAXID.
+                             'getHistogram' only processes energy depositions
+                             in detectors with integer volume ID numbers from 0
+                             to MAXID.
   -o, --filename=OUTPUTFILENAME   Output file name, file will be overwritten!
                              (default: {PATTERN1}_hist.root with a trailing
                              '_t' in PATTERN1 dropped)
@@ -1078,7 +1079,7 @@ shows how to use the script. The meaning of the arguments to the most important 
 * INPUTDIR: This optional argument sets the directory in which getHistogram searches for files to be processed (files containing the patterns) (Default: search in current working directory ".")
 * OUTPUTFILENAME: Name of the output file to be created that will contain the histograms. Note that an exisiting file will be overwritten! The default behaviour is to use the PATTERN1 value with a possibly trailing _t removed and _hist.root appended. 
 * OUTPUTDIR: This optional argument sets the directory in which getHistogram writes its output histogram file (Default: Use the input directory INPUTDIR)
-* MAXID: Determines the maximum number of volumes for which an output histogram is created. In total, MAXID+1 histograms from 0 to MAXID-1, plus a histogram called `sum` which contains the sum of the MAXID ones, are created. The optimum performance and memory usage can be obtained by numbering the sensitive volumes (using `G4SensitiveDetector::SetDetectorID()`, see also [2.2 Sensitive Detectors](#sensitivedetectors)) from 0 to MAXID. Otherwise, `getHistogram` will create a lot of unnecessary histograms. For example, if MAXID=10 is set, but the simulation only contains two detectors with IDs 0 and 9, eight empty histograms from 1 to 8 will be in the output of `getHistogram`. On the other hand, if MAXID is lower than the number of sensitive detectors, a warning will be printed every time a volume is encountered whose number is larger. (Default MAXID is 12)
+* MAXID: This optional argument determines the highest volume ID for which an output histogram is created. In total MAXID + 2 energy deposition histograms (for detectors 0 to MAXID, and a histogram called `sum` which contains the sum of all other ones) are created.  The optimum performance and memory usage can be obtained by numbering the sensitive volumes (using `G4SensitiveDetector::SetDetectorID()`, see also [2.2 Sensitive Detectors](#sensitivedetectors)) from 0 to MAXID. Otherwise, `getHistogram` will create a lot of unnecessary histograms. For example, if MAXID=10 is set, but the simulation only contains two detectors with IDs 0 and 10, eight empty histograms from 1 to 9 will be in the output of `getHistogram`. On the other hand warnings will be printed when a volume is encountered whose number is larger than MAXID. (Default MAXID is 12)
 * MULTIPLICITY: Determines how many events per detector should be accumulated before adding the energy deposition to the histogram. This can be used, for example, to simulate higher multiplicity events in a detector: Imagine two photons with energies of 511 keV hit a detector and deposit all their energy. However, the two events cannot be distinguished by the detector due to pileup, so a single event with an energy of 1022 keV will be added to the spectrum in the experiment. Similarly, Geant4 simulates event by event. In order to simulate pileup of n events, set MULTIPLICITY to n. (Default: MULTIPLICITY is 1)
 * BIN: Number of the histogram bin that should be printed to the screen while executing `getHistogram`. This option was introduced because often, one is only interested in the content of a special bin in the histograms (for example the full-energy peak). If the histograms are defined such that bin `3001` contains the events with an energy deposition between `2.9995 MeV` and `3.0005 MeV` and so on, so there is an easy correspondence between bin number and energy. (The default for BIN is -1, disabling the output)
 
@@ -1257,6 +1258,9 @@ listing all available options with their effect and default values
 #                                     # to utr's code directory and using all
 #                                     # other supplied paths relative to it
 #                                     # (Default: True)
+#ensureTerminalMultiplexer=False      # Whether to warn and abort if utrwrapper.py
+#                                     # is not run inside a tmux or GNU Screen
+#                                     # session (Default: False)
 #cmakeArgs=--debug-output             # Pure string of additional arguments to
 #                                     # cmake on utr, see also [utrBuildOptions]
 #                                     # section (Default: None)
@@ -1295,6 +1299,7 @@ listing all available options with their effect and default values
 #USE_TARGETS=ON                       # Example
 #GENERATOR_ANGCORR=OFF                # Example
 #GENERATOR_ANGDIST=ON                 # Example
+#ZERODEGREE_OFFSET=30                 # Example
 
 #[getHistogramArgs]                   # Optional section with additional longform
 #                                     # options (--LONGOPTION=VALUE) to getHistogram

--- a/macros/examples/utrwrapper-angdist-example.xmac
+++ b/macros/examples/utrwrapper-angdist-example.xmac
@@ -12,7 +12,7 @@
 #filenamePrefix=AngDist_0+_1+_2+_Delta=
 #filenameSuffix=
 #filenameTemplate={filenamePrefix}{loopVar}
-#setterCmd=/ang/delta12 {loopVar}
+#setterCmd=/ang/delta23 {loopVar}
 
 #[utrBuildOptions]
 #CAMPAIGN=Campaign_2014_2015


### PR DESCRIPTION
- GetHistogram now skips also entries of volumes > MAXID at the start of the root file
- GetHistogram's MAXID definition was unified again (in README, code and --usage message)
- reintroduced utrwrapper TMUX/Screen check as ensureTerminalMultiplexer config option (default off)
- Fixed a minor mistake in an utrwrapper example